### PR TITLE
Allow increment and decrement together

### DIFF
--- a/src/plugins/karma.rs
+++ b/src/plugins/karma.rs
@@ -156,9 +156,7 @@ impl KarmaPlugin {
 
         // Loop through all captures, adding them to the output.
         for capture in captures {
-            let name = &capture[1].trim_start_matches('"').trim_end_matches('"');
-
-            let cleaned_name = Karma::sanitize_name(name);
+            let cleaned_name = Karma::sanitize_name(&capture[1].trim_matches('"'));
 
             match parse_karma_change(&capture[2]) {
                 Ok(change) => {

--- a/src/plugins/karma.rs
+++ b/src/plugins/karma.rs
@@ -65,44 +65,40 @@ fn parse_karma_change(change_str: &str) -> Result<i32> {
     let missing_successive_minus = "you need at least two successive \"-\"s to decrement, silly!";
 
     for c in change_str.chars() {
-        match c {
-            '+' => match state {
-                ParseState::Nothing => {
-                    state = ParseState::ChangeToAdd;
-                }
-                ParseState::ChangeToAdd => {
-                    state = ParseState::Add;
-                    counter += 1;
-                }
-                ParseState::Add => {
-                    counter += 1;
-                }
-                ParseState::ChangeToSubtract => {
-                    return Err(format_err!(missing_successive_plus));
-                }
-                ParseState::Subtract => {
-                    state = ParseState::ChangeToAdd;
-                }
-            },
-            '-' => match state {
-                ParseState::Nothing => {
-                    state = ParseState::ChangeToSubtract;
-                }
-                ParseState::ChangeToAdd => {
-                    return Err(format_err!(missing_successive_minus));
-                }
-                ParseState::Add => {
-                    state = ParseState::ChangeToSubtract;
-                }
-                ParseState::ChangeToSubtract => {
-                    state = ParseState::Subtract;
-                    counter -= 1;
-                }
-                ParseState::Subtract => {
-                    counter -= 1;
-                }
-            },
-            unsupported_char => {
+        match (c, &state) {
+            ('+', ParseState::Nothing) => {
+                state = ParseState::ChangeToAdd;
+            }
+            ('+', ParseState::ChangeToAdd) => {
+                state = ParseState::Add;
+                counter += 1;
+            }
+            ('+', ParseState::Add) => {
+                counter += 1;
+            }
+            ('+', ParseState::ChangeToSubtract) => {
+                return Err(format_err!(missing_successive_plus));
+            }
+            ('+', ParseState::Subtract) => {
+                state = ParseState::ChangeToAdd;
+            }
+            ('-', ParseState::Nothing) => {
+                state = ParseState::ChangeToSubtract;
+            }
+            ('-', ParseState::ChangeToAdd) => {
+                return Err(format_err!(missing_successive_minus));
+            }
+            ('-', ParseState::Add) => {
+                state = ParseState::ChangeToSubtract;
+            }
+            ('-', ParseState::ChangeToSubtract) => {
+                state = ParseState::Subtract;
+                counter -= 1;
+            }
+            ('-', ParseState::Subtract) => {
+                counter -= 1;
+            }
+            (unsupported_char, _) => {
                 return Err(format_err!(
                     "character \"{}\" not supported by the Karma Adjustment Bureau",
                     unsupported_char

--- a/src/plugins/karma.rs
+++ b/src/plugins/karma.rs
@@ -185,9 +185,9 @@ impl KarmaPlugin {
             write!(line, "{}'s karma is now {}", name, karma.score)?;
 
             if raw_change != change {
-                line.push_str(" Buzzkill Mode (tm) enforced a limit of 5");
+                line.push_str(". Buzzkill Mode (tm) enforced a limit of 5");
             } else if raw_change == 0 {
-                line.push_str(" Well done. Nothing happened.");
+                line.push_str(". Well done. Nothing happened.");
             }
 
             lines.push(line);

--- a/src/plugins/karma.rs
+++ b/src/plugins/karma.rs
@@ -188,6 +188,8 @@ impl KarmaPlugin {
 
             if raw_change != change {
                 line.push_str(" Buzzkill Mode (tm) enforced a limit of 5");
+            } else if raw_change == 0 {
+                line.push_str(" Well done. Nothing happened.");
             }
 
             lines.push(line);

--- a/src/plugins/karma.rs
+++ b/src/plugins/karma.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::convert::TryInto;
 use std::fmt::Write;
 
 use regex::Regex;
@@ -47,10 +46,89 @@ pub struct KarmaPlugin {
     re: Regex,
 }
 
+enum ParseState {
+    Nothing,
+
+    ChangeToAdd,
+    Add,
+
+    ChangeToSubtract,
+    Subtract,
+}
+
+/// Parse an input karma change string and return the resulting delta
+fn parse_karma_change(change_str: &str) -> Result<i32> {
+    let mut state = ParseState::Nothing;
+    let mut counter = 0;
+
+    let missing_successive_plus = "you need at least two successive \"+\"s to increment, silly!";
+    let missing_successive_minus = "you need at least two successive \"-\"s to decrement, silly!";
+
+    for c in change_str.chars() {
+        match c {
+            '+' => match state {
+                ParseState::Nothing => {
+                    state = ParseState::ChangeToAdd;
+                }
+                ParseState::ChangeToAdd => {
+                    state = ParseState::Add;
+                    counter += 1;
+                }
+                ParseState::Add => {
+                    counter += 1;
+                }
+                ParseState::ChangeToSubtract => {
+                    return Err(format_err!(missing_successive_plus));
+                }
+                ParseState::Subtract => {
+                    state = ParseState::ChangeToAdd;
+                }
+            },
+            '-' => match state {
+                ParseState::Nothing => {
+                    state = ParseState::ChangeToSubtract;
+                }
+                ParseState::ChangeToAdd => {
+                    return Err(format_err!(missing_successive_minus));
+                }
+                ParseState::Add => {
+                    state = ParseState::ChangeToSubtract;
+                }
+                ParseState::ChangeToSubtract => {
+                    state = ParseState::Subtract;
+                    counter -= 1;
+                }
+                ParseState::Subtract => {
+                    counter -= 1;
+                }
+            },
+            unsupported_char => {
+                return Err(format_err!(
+                    "character \"{}\" not supported by the Karma Adjustment Bureau",
+                    unsupported_char
+                ));
+            }
+        }
+    }
+
+    match state {
+        ParseState::ChangeToAdd => Err(format_err!(missing_successive_plus)),
+        ParseState::ChangeToSubtract => Err(format_err!(missing_successive_minus)),
+        ParseState::Nothing => {
+            // This state should be impossible given the regex we use, but
+            // why not be safe?
+            Err(format_err!(
+                "you didn't even try to adjust karma on this one!"
+            ))
+        }
+        ParseState::Add | ParseState::Subtract => Ok(counter),
+    }
+}
+
 impl KarmaPlugin {
     pub fn new() -> Self {
         KarmaPlugin {
-            re: Regex::new(r#"([\w]{2,}|".+?")(\+\++|--+)(?:\s|$)"#).unwrap(),
+            re: Regex::new(r#"([\w]{2,}|".+?")([+-]+)(?:\s|$)"#).unwrap(),
         }
     }
 }
@@ -69,54 +147,56 @@ impl KarmaPlugin {
     async fn handle_privmsg(&self, ctx: &Arc<Context>, msg: &str) -> Result<()> {
         let captures: Vec<_> = self.re.captures_iter(msg).collect();
 
-        if !captures.is_empty() {
-            let mut changes = BTreeMap::new();
-
-            // Loop through all captures, adding them to the output.
-            for capture in captures {
-                let mut name = &capture[1];
-
-                // TODO: switch to strip_prefix and strip_suffix when they're available.
-                if name.starts_with('"') && name.ends_with('"') {
-                    name = &name[1..name.len() - 1];
-                }
-
-                // Len returns a usize which won't fit in an i64, so we need to try and
-                // convert it.
-                let mut change: i32 = (&capture[2].len() - 1).try_into()?;
-                if capture[2].starts_with('-') {
-                    change *= -1;
-                }
-
-                let cleaned_name = Karma::sanitize_name(name);
-                *changes.entry(cleaned_name).or_insert(0) += change;
-            }
-
-            let mut first = true;
-            let mut out = String::new();
-
-            let db = ctx.get_db();
-
-            for (name, raw_change) in changes.into_iter() {
-                let change = utils::clamp(raw_change, -5, 5);
-
-                let karma = Karma::create_or_update(&db, &name, change).await?;
-                if first {
-                    first = false;
-                } else {
-                    out.push_str(", ");
-                }
-
-                write!(out, "{}'s karma is now {}", name, karma.score)?;
-
-                if raw_change != change {
-                    out.push_str(" Buzzkill Mode (tm) enforced a limit of 5");
-                }
-            }
-
-            // Send the bulk message
-            ctx.reply(&out).await?;
+        if captures.is_empty() {
+            return Ok(());
         }
+
+        let mut changes = BTreeMap::new();
+        let mut change_errors = Vec::new();
+
+        // Loop through all captures, adding them to the output.
+        for capture in captures {
+            let name = &capture[1].trim_start_matches('"').trim_end_matches('"');
+
+            let cleaned_name = Karma::sanitize_name(name);
+
+            match parse_karma_change(&capture[2]) {
+                Ok(change) => {
+                    *changes.entry(cleaned_name).or_insert(0) += change;
+                }
+                Err(e) => {
+                    change_errors.push(format!(
+                        "invalid karma change for \"{}\": {}",
+                        cleaned_name, e
+                    ));
+                }
+            }
+        }
+
+        let db = ctx.get_db();
+
+        let mut lines = Vec::new();
+
+        for (name, raw_change) in changes.into_iter() {
+            let change = utils::clamp(raw_change, -5, 5);
+
+            let karma = Karma::create_or_update(&db, &name, change).await?;
+
+            let mut line = String::new();
+
+            write!(line, "{}'s karma is now {}", name, karma.score)?;
+
+            if raw_change != change {
+                line.push_str(" Buzzkill Mode (tm) enforced a limit of 5");
+            }
+
+            lines.push(line);
+        }
+
+        lines.append(&mut change_errors);
+
+        // Send the bulk message
+        ctx.reply(&lines.join(", ")).await?;
 
         Ok(())
     }
@@ -150,5 +230,70 @@ impl Plugin for KarmaPlugin {
         }
 
         Err(format_err!("karma plugin lagged"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_single_karma_increment() -> Result<()> {
+        assert_eq!(parse_karma_change("++")?, 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_multiple_karma_increment() -> Result<()> {
+        assert_eq!(parse_karma_change("+++")?, 2);
+        assert_eq!(parse_karma_change("++++")?, 3);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_single_karma_decrement() -> Result<()> {
+        assert_eq!(parse_karma_change("--")?, -1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_multiple_karma_decrement() -> Result<()> {
+        assert_eq!(parse_karma_change("---")?, -2);
+        assert_eq!(parse_karma_change("----")?, -3);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_no_karma_change() -> Result<()> {
+        assert_eq!(parse_karma_change("++--")?, 0);
+        assert_eq!(parse_karma_change("--++")?, 0);
+
+        assert_eq!(parse_karma_change("++++----")?, 0);
+        assert_eq!(parse_karma_change("----++++")?, 0);
+
+        assert_eq!(parse_karma_change("++--++--")?, 0);
+        assert_eq!(parse_karma_change("--++--++")?, 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_malformed_karma_change() {
+        assert!(parse_karma_change("").is_err());
+        assert!(parse_karma_change("+").is_err());
+        assert!(parse_karma_change("-").is_err());
+
+        assert!(parse_karma_change("+-").is_err());
+        assert!(parse_karma_change("-+").is_err());
+
+        assert!(parse_karma_change("++-").is_err());
+        assert!(parse_karma_change("--+").is_err());
+
+        assert!(parse_karma_change("++-++").is_err());
+        assert!(parse_karma_change("--+--").is_err());
     }
 }


### PR DESCRIPTION
Allows users to say foo++-- to increment and decrement at the same time.
The delta is stored in the database.