### PR TITLE
Make <prefix>karma use issuer's nick

### DIFF
--- a/src/plugins/karma.rs
+++ b/src/plugins/karma.rs
@@ -218,9 +218,7 @@ impl Plugin for KarmaPlugin {
         while let Ok(ctx) = stream.recv().await {
             let res = match ctx.as_event() {
                 Ok(Event::Command("karma", possible_arg)) => {
-                    let nick = possible_arg.or_else(|| ctx.sender());
-
-                    match nick {
+                    match possible_arg.or_else(|| ctx.sender()) {
                         Some(nick) => self.handle_karma(&ctx, nick).await,
                         None => Err(format_err!(
                             "no nick found to use for karma check (not provided in source message)"

--- a/src/plugins/karma.rs
+++ b/src/plugins/karma.rs
@@ -218,6 +218,14 @@ impl Plugin for KarmaPlugin {
         while let Ok(ctx) = stream.recv().await {
             let res = match ctx.as_event() {
                 Ok(Event::Command("karma", Some(arg))) => self.handle_karma(&ctx, arg).await,
+                Ok(Event::Command("karma", None)) => {
+                    self.handle_karma(
+                        &ctx,
+                        ctx
+                            .sender()
+                            .ok_or_else(|| format_err!("no nick found to use for karma check (not provided in source message)"))?,
+                    ).await
+                }
                 Ok(Event::Message(_, msg)) => self.handle_privmsg(&ctx, msg).await,
                 _ => Ok(()),
             };


### PR DESCRIPTION
`<prefix>karma` previously did nothing. This change makes it instead use
the nick of the person that sent the command. Matches older behavior of
the `<prefix>karma` command.