### PR TITLE
[barista] Add initial !pop (and soda) support

### DIFF
--- a/src/plugins/barista/mod.rs
+++ b/src/plugins/barista/mod.rs
@@ -30,6 +30,13 @@ impl BaristaPlugin {
             .await?;
         Ok(())
     }
+    async fn handle_pop(&self, ctx: &Arc<Context>, arg: Option<&str>) -> Result<()> {
+        let target = arg.or_else(|| ctx.sender()).unwrap_or("someone");
+        let action = ACTIONS.choose(&mut rand::thread_rng()).unwrap();
+        ctx.action_reply(&format!("{} {} a {}!", action, target, pop::prepare()))
+            .await?;
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -50,6 +57,11 @@ impl Plugin for BaristaPlugin {
                 short_help: "usage: tea. Get some tea from the bot.".to_string(),
                 full_help: "a barista to give you tea.".to_string(),
             },
+            CommandMetadata {
+                name: "pop".to_string(),
+                short_help: "usage: pop. Get some pop from the bot.".to_string(),
+                full_help: "a barista to give you pop.".to_string(),
+            },
         ]
     }
 
@@ -60,6 +72,7 @@ impl Plugin for BaristaPlugin {
             let res = match ctx.as_event() {
                 Ok(Event::Command("coffee", arg)) => self.handle_coffee(&ctx, arg).await,
                 Ok(Event::Command("tea", arg)) => self.handle_tea(&ctx, arg).await,
+                Ok(Event::Command("pop", arg)) => self.handle_pop(&ctx, arg).await,
                 _ => Ok(()),
             };
 

--- a/src/plugins/barista/mod.rs
+++ b/src/plugins/barista/mod.rs
@@ -62,6 +62,11 @@ impl Plugin for BaristaPlugin {
                 short_help: "usage: pop. Get some pop from the bot.".to_string(),
                 full_help: "a barista to give you pop.".to_string(),
             },
+            CommandMetadata {
+                name: "soda".to_string(),
+                short_help: "usage: soda. Get some soda from the bot.".to_string(),
+                full_help: "it's the same as pop, but not.".to_string(),
+            },
         ]
     }
 
@@ -73,6 +78,7 @@ impl Plugin for BaristaPlugin {
                 Ok(Event::Command("coffee", arg)) => self.handle_coffee(&ctx, arg).await,
                 Ok(Event::Command("tea", arg)) => self.handle_tea(&ctx, arg).await,
                 Ok(Event::Command("pop", arg)) => self.handle_pop(&ctx, arg).await,
+                Ok(Event::Command("soda", arg)) => self.handle_pop(&ctx, arg).await,
                 _ => Ok(()),
             };
 

--- a/src/plugins/barista/mod.rs
+++ b/src/plugins/barista/mod.rs
@@ -8,6 +8,7 @@ use rand::seq::SliceRandom;
 use crate::prelude::*;
 
 mod coffee;
+mod pop;
 mod tea;
 
 const ACTIONS: &[&str] = &["hands", "gives", "passes", "serves"];
@@ -30,6 +31,7 @@ impl BaristaPlugin {
             .await?;
         Ok(())
     }
+
     async fn handle_pop(&self, ctx: &Arc<Context>, arg: Option<&str>) -> Result<()> {
         let target = arg.or_else(|| ctx.sender()).unwrap_or("someone");
         let action = ACTIONS.choose(&mut rand::thread_rng()).unwrap();

--- a/src/plugins/barista/pop.rs
+++ b/src/plugins/barista/pop.rs
@@ -1,5 +1,4 @@
 use rand::seq::SliceRandom;
-use rand::Rng;
 
 const POPS: &[&str] = &[
     "Coke",
@@ -11,30 +10,24 @@ const POPS: &[&str] = &[
     "Sun Drop",
 ];
 const POP_SIZES: &[&str] = &[
-    "small", "medium", "large", "extra large", "CostCo sized", "12 oz", "2 L",
+    "small",
+    "medium",
+    "large",
+    "extra large",
+    "CostCo sized",
+    "12 oz",
+    "2 L",
 ];
-const POP_STYLES: &[&str] = &[
-    "sizzling",
-    "bubbling",
-    "flat",
-];
-const POP_HEATS: &[&str] = &[
-    "iced",
-    "cold",
-    "lukewarm",
-    "room temp",
-];
+const POP_STYLES: &[&str] = &["sizzling", "bubbling", "flat"];
+const POP_HEATS: &[&str] = &["iced", "cold", "lukewarm", "room temp"];
 
 pub(crate) fn prepare() -> String {
     let mut rng = rand::thread_rng();
 
     let size = POP_SIZES.choose(&mut rng).unwrap();
     let heat = POP_HEATS.choose(&mut rng).unwrap();
-    let flavor = POP_FLAVORS.choose(&mut rng).unwrap();
+    let style = POP_STYLES.choose(&mut rng).unwrap();
     let pop = POPS.choose(&mut rng).unwrap();
 
-    format!(
-        "{} {} {} {}",
-        size, style, heat, pop, 
-    )
+    format!("{} {} {} {}", size, style, heat, pop)
 }

--- a/src/plugins/barista/pop.rs
+++ b/src/plugins/barista/pop.rs
@@ -1,0 +1,40 @@
+use rand::seq::SliceRandom;
+use rand::Rng;
+
+const POPS: &[&str] = &[
+    "Coke",
+    "Diet Coke",
+    "Coke Zero",
+    "Pepsi",
+    "Diet Pepsi",
+    "Mountain Dew",
+    "Sun Drop",
+];
+const POP_SIZES: &[&str] = &[
+    "small", "medium", "large", "extra large", "CostCo sized", "12 oz", "2 L",
+];
+const POP_STYLES: &[&str] = &[
+    "sizzling",
+    "bubbling",
+    "flat",
+];
+const POP_HEATS: &[&str] = &[
+    "iced",
+    "cold",
+    "lukewarm",
+    "room temp",
+];
+
+pub(crate) fn prepare() -> String {
+    let mut rng = rand::thread_rng();
+
+    let size = POP_SIZES.choose(&mut rng).unwrap();
+    let heat = POP_HEATS.choose(&mut rng).unwrap();
+    let flavor = POP_FLAVORS.choose(&mut rng).unwrap();
+    let pop = POPS.choose(&mut rng).unwrap();
+
+    format!(
+        "{} {} {} {}",
+        size, style, heat, pop, 
+    )
+}


### PR DESCRIPTION
I've never really written Rust but, I can copy and edit! This is a variant of the `!coffee` command but, for getting pops. If I new Rust/had time right now, I'd also allow `!soda` but, this lunch break only can last so long! 